### PR TITLE
Provide an advanced component store

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ class TestPage extends LayoutManagerPage
 }
 ```
 This passes your data `['company'=>'Apple']` to your widget in a `data` property. You can access that in your `mount()` function or via a direct property like any Livewire component.
-
+```php
+class CompaniesWidget extends BaseWidget
+{
+    public array $data;
+    public function mount($data){
+        $this->data = $data;
+    }
+//... other methods & properties
+}
+```
 
 ### Renaming Selection Options
 The names associated with your selected components can be changed by overriding the `getComponentSelectOptions` method in your custom page. Be sure to order the array you provided to match the order of the components you provided

--- a/README.md
+++ b/README.md
@@ -303,10 +303,27 @@ Filament does provide a `persistToSession()` option for tables, but this does no
 I've provided a livewire event for you to utilize for this purpose.
 
 Each livewire component rendered through your layout manager is passed a value called `container_key` used to keep track of its data. 
-Each livewire component can additionally dispatch an event to let the `LayoutManager` class to update component specific data that can then be persisted to
-a database and reloaded across sessions, for example.
+Component specific data is passed via the `store` property.
 
-#### Updating the Store
+Each livewire component can dispatch an event to the `LayoutManager` class to update it's `store` which is saved alongside your layout data.
+
+### Getting the component key and store
+
+Be sure to define the `container_key` and `store` property in your widget or component class, either directly or via the mount property.
+```php
+/* 
+Provide the following as part of your child component (like a widget class), to get the id and your data (in store).
+*/
+public $container_key;
+public $store;
+
+public function mount($container_key, $store){
+    $this->container_key = $container_key;
+    $this->store = $store;
+}
+```
+
+### Updating the component's store
 Execute the following anywhere in your child-component (like a table widget), while replacing the `store: []` with actual data.
 ```php
 $this->dispatch('component-store-update',
@@ -314,32 +331,13 @@ $this->dispatch('component-store-update',
     store: []
 );
 ```
+(For example, I dispatch the above in my table widget where store is all the current table filters)
 
-Be sure to define the `container_key` property in your widget or component class, either directly or via the mount property.
-```php
-/* Include this property in your class. */
-public $container_key;
 
-/* 
-You can also assign it directly via the mount method. 
-Livewire allows you to skip this if you prefer and just declare the propery 
-*/
-public $container_key;
+### Using the store
+Your components `store` property is passed just like any livewire property on reloads of your layout.
 
-public function mount($container_key){
-    $this->container_key = $container_key;
-}
-```
-
-#### Loading the store
-Loading the store is up to you. I needed to load from my component specific store and update the pre-applied table filters. An example of that follows:
-```php
-public function mount() {
-    $this->tableFilters = $this->store['tableFilters'];
-}
-```
-Of course, you can access the `store` anywhere in your component as its passed in as a livewire property. Update your data wherever it needs it.
-#### Customizing
+### Customizing
 This `component-store-update` event method is present in `LayoutManager` meaning if you want to change it's behaviour, you are free to do so in your custom layout manager.
 
 How to create a custom layout manager is detail above in this README.

--- a/resources/views/layout-manager.blade.php
+++ b/resources/views/layout-manager.blade.php
@@ -77,8 +77,9 @@
                 @endif
                 <livewire:dynamic-component
                     :is="$component['type']['widget_class']"
-                    :data="$component['type']['data']"
+                    :data="$component['type']['data'] ?? []"
                     :container_key="$id"
+                    :store="$component['store'] ?? []"
                     :key="$id"
                 />
             </div>

--- a/resources/views/layout-manager.blade.php
+++ b/resources/views/layout-manager.blade.php
@@ -75,11 +75,12 @@
                         </div>
                     </div>
                 @endif
-                @livewire(
-                    $component['type']['widget_class'],
-                    $component['type']['data'],
-                    key("{$component['type']['widget_class']}-{$id}"),
-                )
+                <livewire:dynamic-component
+                    :is="$component['type']['widget_class']"
+                    :data="$component['type']['data']"
+                    :container_key="$id"
+                    :key="$id"
+                />
             </div>
         @endforeach
     </div>

--- a/src/Http/Livewire/LayoutManager.php
+++ b/src/Http/Livewire/LayoutManager.php
@@ -9,6 +9,7 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithHeaderActions;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 
@@ -109,7 +110,7 @@ class LayoutManager extends Component implements HasActions, HasForms
         $this->container[$this->currentLayout][uniqid()] = [
             'cols' => 1,
             'type' => $this->settings['components'][$this->selectedComponent],
-            'event_id' => count($this->container) + 1,
+            'store' => [],
         ];
     }
 
@@ -196,6 +197,12 @@ class LayoutManager extends Component implements HasActions, HasForms
     protected function save(): void
     {
         session(['layout_manager' => $this->container]);
+    }
+
+    #[On('component-store-update')]
+    public function componentStoreUpdate($id, $store): void
+    {
+        $this->container[$this->currentLayout][$id]['store'] = $store;
     }
 
     protected function load(): void

--- a/src/Http/Livewire/LayoutManager.php
+++ b/src/Http/Livewire/LayoutManager.php
@@ -203,6 +203,9 @@ class LayoutManager extends Component implements HasActions, HasForms
     public function componentStoreUpdate($id, $store): void
     {
         $this->container[$this->currentLayout][$id]['store'] = $store;
+        if (! $this->editMode) {
+            $this->save();
+        }
     }
 
     protected function load(): void


### PR DESCRIPTION
#### Description
The following provides users the ability to store and load component specific data into their layouts.

#### Use Case
Say your have two table widgets on your layout. You may want to save any active filters applied to them across loads. 

With this change, users can dispatch events in their table widgets which contain the data about their table filters, which is then persisted to a database (or session, or file, etc.) so that reloads preserve the active filters.